### PR TITLE
added null handling when item isnt created

### DIFF
--- a/BranchPresets/BranchPresets.csproj
+++ b/BranchPresets/BranchPresets.csproj
@@ -144,6 +144,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\ASOS.Content.Sitecore.Binaries.8.2.170407.1\lib\net452\System.Web.Mvc.dll</HintPath>


### PR DESCRIPTION
occasions when the item isnbt created (for example if an item created event has fired and stops the creation of the item), cause a null ref exception